### PR TITLE
clearing screen should also reset cursor

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1399,6 +1399,7 @@ end
 
 function cls()
 	__screen:clear(0,0,0,255)
+	__pico_cursor = {0,0}
 end
 
 __pico_camera_x = 0


### PR DESCRIPTION
to see this, use

``` lua
cls()
print("test") --without coordinate
```

the text will scroll down the screen in picolove, as it is missing the `cursor(0,0)`
