### PR TITLE
fixes print color issues

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1159,9 +1159,9 @@ function love.keypressed(key)
 	if cart and cart._keydown then
 		return cart._keydown(key)
 	end
-	if key == 'r' and love.keyboard.isDown('lctrl') then
+	if key == 'r' and (love.keyboard.isDown('lctrl') or love.keyboard.isDown('lgui')) then
 		reload()
-	elseif key == 'q' and love.keyboard.isDown('lctrl') then
+	elseif key == 'q' and (love.keyboard.isDown('lctrl') or love.keyboard.isDown('lgui')) then
 		love.event.quit()
 	elseif key == 'pause' then
 		paused = not paused
@@ -1170,7 +1170,7 @@ function love.keypressed(key)
 		local screenshot = love.graphics.newScreenshot(false)
 		local filename = cartname..'-'..os.time()..'.png'
 		screenshot:encode(filename)
-		log('saved screenshort to',filename)
+		log('saved screenshot to',filename)
 	elseif key == 'f8' then
 		-- start recording
 		video_frames = {}

--- a/main.lua
+++ b/main.lua
@@ -343,7 +343,7 @@ vec4 effect(vec4 color, Image texture, vec2 texture_coords, vec2 screen_coords) 
 	camera()
 	pal()
 	palt()
-	color(0)
+  color(6)
 
 	_load(argv[2] or 'nocart.p8')
 	run()
@@ -1114,7 +1114,7 @@ function flip_screen()
 	love.graphics.setCanvas()
 	love.graphics.origin()
 
-	love.graphics.setColor(255,255,255,255)
+  -- love.graphics.setColor(255,255,255,255)
 	love.graphics.setScissor()
 
 	love.graphics.clear()


### PR DESCRIPTION
—sets print color on cart load to light grey (6) to match pico8.
—comment out setColor which was overwriting color() changes on each frame
—added mac keyboard shortcuts
—corrected a typo
