### PR TITLE
do nothing on empty command

### DIFF
--- a/nocart.p8
+++ b/nocart.p8
@@ -48,6 +48,8 @@ function _keydown(key)
 			folder()
 		elseif linebuffer == 'run' then
 			run()
+		elseif #linebuffer == 0 then
+			--do nothing
 		else
 			_call(linebuffer)
 		end


### PR DESCRIPTION
no need to run _call if the line is empty
