### PR TITLE
Fix lua patcher handling comments

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -829,14 +829,18 @@ function load_p8(filename)
 	lua = lua:gsub('!=','~=')
 	-- rewrite shorthand if statements eg. if (not b) i=1 j=2
 	lua = lua:gsub('if%s*(%b())%s*([^\n]*)\n',function(a,b)
-		local nl = a:find('\n')
+		local nl = a:find('\n',nil,true)
 		local th = b:find('%f[%w]then%f[%W]')
 		local an = b:find('%f[%w]and%f[%W]')
 		local o = b:find('%f[%w]or%f[%W]')
-		if nl or th or an or o then
-			return string.format('if %s %s\n',a,b)
-		else
-			return 'if '..a:sub(2,#a-1)..' then '..b..' end\n'
+		local ce = b:find('--',nil,true)
+		if not (nl or th or an or o) then
+			if ce then
+				local c,t = b:match("(.-)(%s-%-%-.*)")
+				return 'if '..a:sub(2,-2)..' then '..c..' end'..t..'\n'
+			else
+				return 'if '..a:sub(2,-2)..' then '..b..' end\n'
+			end
 		end
 	end)
 	-- rewrite assignment operators


### PR DESCRIPTION
Lines like: `if (expression) do_something -- comment`
Get incorrectly patched to `if expression then do_something -- comment end`

This PR fixes that issue (also cleans up some of the sub lines)
