### PR TITLE
Fix compatibility with newer cart versions (>8)

### DIFF
--- a/cart.lua
+++ b/cart.lua
@@ -200,9 +200,9 @@ function cart.load_p8(filename)
 
 		-- decompress code
 		log('version', version)
-		if version>8 then
-			error(string.format('unknown file version %d',version))
-		end
+--		if version>8 then
+--			error(string.format('unknown file version %d',version))
+--		end
 
 		if compressed then
 			lua = decompress(lua)


### PR DESCRIPTION
Version numbers are incremented with PICO-8 builds, but no file format changes have been made so far, version checking seems irrelevant.

This fixes https://github.com/picolove/picolove/issues/77

To make most carts work, more changes are required, see my other PRs.
Or my workarounds branch: https://github.com/hrobeers/picolove/tree/workarounds