### PR TITLE
workaround: LuaJIT does not support binary numeric literals.

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -819,6 +819,8 @@ end
 
 function patch_lua(lua)
 	-- patch lua code
+	lua = lua:gsub("0b1000","8")
+	lua = lua:gsub("0b","")
 	lua = lua:gsub("!=","~=")
 	lua = lua:gsub("//","--")
 	-- rewrite shorthand if statements eg. if (not b) i=1 j=2


### PR DESCRIPTION
This workaround messes up rendering of fill patterns, but at least it runs.
A more experienced Lua programmer should be able to fix this properly, but for now I believe it is more important to make PICO-8 games at least playable.

This is a requirement to make fuz work:
![Fuz Cartridge](https://www.lexaloffle.com/bbs/cposts/fu/fuz_v1-1.p8.png)

To make most carts work, more changes are required, see my other PRs.
Or my workarounds branch: https://github.com/hrobeers/picolove/tree/workarounds