### PR TITLE
Workaround for print failure on non-UTF8 chars

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -286,8 +286,9 @@ function api.print(str, x, y, col)
 		api.color(c)
 		api.cursor(0, y+6)
 	end
+	local to_print = tostring(str):gsub("[^%z\32-\127]", "#")
 	love.graphics.setShader(pico8.text_shader)
-	love.graphics.print(tostring(str), flr(x), flr(y))
+	love.graphics.print(to_print, flr(x), flr(y))
 end
 
 api.printh=print


### PR DESCRIPTION
Replace non-printable ASCII chars as love.graphics.print refuses to print non-UTF8 chars.

PICO-8 seems to have invented some non-UTF8 chars for icons.

This is a requirement to make fuz work:
![Fuz Cartridge](https://www.lexaloffle.com/bbs/cposts/fu/fuz_v1-1.p8.png)

To make most carts work, more changes are required, see my other PRs.
Or my workarounds branch: https://github.com/hrobeers/picolove/tree/workarounds