### PR TITLE
Add oval and ovalfill functions; update rnd function

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1150,7 +1150,23 @@ function api.cstore(dest_addr, source_addr, len) -- luacheck: no unused
 end
 
 function api.rnd(x)
-	return love.math.random() * (x or 1)
+	local t = type(x)
+	assert(t == "number" or t == "table", "rnd() accepts a number or a table")
+	if t == "number" then
+		return love.math.random() * (x or 1)
+	elseif t == "table" then
+		local len = #x
+		if len > 0
+		then
+			local index = 0
+			while(index == 0)
+			do
+				index = math.ceil(love.math.random() * len)
+			end
+			return x[index]
+		end
+		return nil
+	end
 end
 
 function api.srand(seed)

--- a/api.lua
+++ b/api.lua
@@ -609,8 +609,8 @@ end
 
 function _ellipse(drawmode, x1, y1, x2, y2, col)
 	assert(drawmode == "line" or drawmode == "fill")
-	assert(x1 ~= nil and x2 ~= nil and x1 <= x2)
-	assert(y1 ~= nil and y2 ~= nil and y1 <= y2)
+	assert(x1 ~= nil and x2 ~= nil)
+	assert(y1 ~= nil and y2 ~= nil)
 	assert((col >= 0 and col <=15) or col == nil)
 
 	if col then

--- a/api.lua
+++ b/api.lua
@@ -599,6 +599,31 @@ function api.circfill(cx, cy, r, col)
 	end
 end
 
+function api.oval(x1, y1, x2, y2, col)
+	_ellipse("line", x1, y1, x2, y2, col)
+end
+
+function api.ovalfill(x1, y1, x2, y2, col)
+	_ellipse("fill", x1, y1, x2, y2, col)
+end
+
+function _ellipse(drawmode, x1, y1, x2, y2, col)
+	assert(drawmode == "line" or drawmode == "fill")
+	assert(x1 ~= nil and x2 ~= nil and x1 <= x2)
+	assert(y1 ~= nil and y2 ~= nil and y1 <= y2)
+	assert((col >= 0 and col <=15) or col == nil)
+
+	if col then
+		color(col)
+	end
+
+	local rx = (x2 - x1) / 2
+	local ry = (y2 - y1) / 2
+	local x = x1 + rx
+	local y = y1 + ry
+	love.graphics.ellipse(drawmode, x, y, rx, ry)
+end
+
 function api.line(x0, y0, x1, y1, col)
 	if col then
 		color(col)


### PR DESCRIPTION
These commits update the API.  The `oval` and `ovalfill` functions were added in PICO-8 0.2.1.  The `rnd(table)` addition happened in PICO-8 0.2.0.